### PR TITLE
Make navigation look a bit nicer in firefox

### DIFF
--- a/app/assets/stylesheets/vivus/module/nav.scss
+++ b/app/assets/stylesheets/vivus/module/nav.scss
@@ -6,7 +6,7 @@
   margin: 0;
   background-color: #24281A;
   z-index: 1000000;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   @include respond-to("small") {
     display: none;
@@ -51,7 +51,7 @@
       &.h2 {
         font-size: 13px;
         color: #C3CED0;
-        margin: 0 0 5px 30px;
+        margin: 0 10px 5px 30px;
       }
 
       &.h3 {


### PR DESCRIPTION
My miniscule contribution...
- Made scrollbar automatic instead of always showing
- Added a little bit of margin to the right of the level 2 style headings

Screenshots:

Before, you can see the scrollbar is slammed right up against the text.

![beforewwewew](https://cloud.githubusercontent.com/assets/2295892/2628109/2333c9c8-be1e-11e3-8533-80acbd94afc5.png)

After, it only shows if it's necessary. When it does show the text has a margin so it still looks SWELL

![screenshot from 2014-04-07 16 29 01](https://cloud.githubusercontent.com/assets/2295892/2628116/5f19db8a-be1e-11e3-820c-653f4298bdc4.png)

![screenshot from 2014-04-07 16 29 15](https://cloud.githubusercontent.com/assets/2295892/2628117/627bf0d8-be1e-11e3-9a84-a4932260e97c.png)
